### PR TITLE
add clear method to remove all entries

### DIFF
--- a/lib/Cache/LRU.pm
+++ b/lib/Cache/LRU.pm
@@ -64,6 +64,13 @@ sub get {
     $$value_ref;
 }
 
+sub clear {
+    my $self = shift;
+
+    $self->{_entries} = {};
+    $self->{_fifo} = [];    
+}
+
 sub _update_fifo {
     # precondition: $self->{_entries} should contain given key
     my ($self, $key, $value_ref) = @_;
@@ -125,6 +132,10 @@ Stores the given key-value pair.
 =head2 $cache->remove($key)
 
 Removes data associated to the given key and returns the old value, if any.
+
+=head2 $cache->clear($key)
+
+Removes all entries from the cache.
 
 =head1 AUTHOR
 

--- a/t/00base.t
+++ b/t/00base.t
@@ -50,4 +50,8 @@ is $cache->get('c'), 3;
 ok ! defined $cache->get('d');
 is $cache->get('e'), 6;
 
+$cache->clear;
+ok ! defined $cache->get('c');
+ok ! defined $cache->get('e');
+
 done_testing;


### PR DESCRIPTION
I  needed a way to clear the entire cache object so I added a clear() method. Very trivial but please consider merging (I'm using Cache::LRU for the cache object in Kelp::Routes, and it demands a clear() function be available).
